### PR TITLE
Adding in position-x and position-y props

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ And put into your DOM
   image-class="cam-viewport"
   background-size="cover"
   :image-success-callback="successCallback"
-  :image-error-callback="errorCallback">
+  :image-error-callback="errorCallback"
+  position-x="30%"
+  position-y="66%">
 </lazy-background>
 ```
 
@@ -62,6 +64,8 @@ Width and height are for the *image* not the containing div.
 * error-image - Path to the error image (required)
 * image-class - Any classes you wish to include on the image (optional)
 * background-size - CSS background-size value (optional, default is `cover`)
+* position-x - CSS background-position-x value (optional, default is `50%`)
+* position-y - CSS background-position-y value (optional, default is `50%`)
 * image-success-callback - Function on success (optional)
 * image-error-callback - Function on error (optional)
 
@@ -85,6 +89,10 @@ is the dimensions of the actual image (not the rendered div)
 #### Background size
 
 This is `cover` by default although it can be overridden.
+
+#### Background position
+
+Set with values from two different props, `position-x` and `position-y` this will set the background-position. Useful for setting focal points on images that could appear at different dimensions to ensure odd cropping doesn't occur. 
 
 #### Callbacks
 

--- a/VueLazyBackgroundImage.vue
+++ b/VueLazyBackgroundImage.vue
@@ -36,6 +36,16 @@ export default {
       type: String,
       required: false,
       default: 'cover'
+    },
+    positionX: {
+      type: String,
+      required: false,
+      default: '50%'
+    },
+    positionY: {
+      type: String,
+      required: false,
+      default: '50%'
     }
   },
   data() {
@@ -57,7 +67,7 @@ export default {
       }
 
       if (this.imageState === 'loaded') {
-        return 'background-image: url(' + this.asyncImage.src + '); background-size: ' + this.backgroundSize
+        return 'background-image: url(' + this.asyncImage.src + '); background-size: ' + this.backgroundSize + '; background-position: ' + this.positionX + ' ' + this.positionY
       }
 
       return '';


### PR DESCRIPTION
Hey there,

I know this plugin hasn't been touched in a while, but I plan on using this for an upcoming project. We have an article list that displays featured images at varying dimensions and aspect ratios, which means that sometimes odd crops come up and people's faces get cut off, creating a less than desirable design.

To fix this we are leveraging the focal point plugin from our CMS contentful, which allows you to select a point on the image, and it saves an X and Y value along with the image.

I've added in two new props to allow users to add in an inline background-position css style, on top of the background-size prop that is already there.